### PR TITLE
adding config for ReadtheDocs site for mkdocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,10 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation with MkDocs
+mkdocs:
+  configuration: mkdocs.yml

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,12 +2,14 @@
 
 ## Utility Scripts
 
+* `ocp-upgrade-paths.sh` - lists available OCP upgrade paths
 * `setup_nfs_provisioner.sh` - sets up a NFS share on the system, exports it, installs NFS provisioner pod to support dynamically provision PVs on NFS
 
 ## KnowledgeBase
 
 * [How to troubleshoot Pending Pods](h2t-pending-pods)
 * [How to troubleshoot Resource Exhaustion situation](h2t-resource-exhaustion)
+* [How to troubleshoot Security Context (SCC) issues](h2t-scc)
 * and more to come!
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,1 +1,1 @@
-site_name: My Docs
+site_name: openshift-ppc64le


### PR DESCRIPTION
Sphinx is the default doc tool that the site assumes. Need to add a config to make it explicit for using `mkdocs` and its config, per: https://docs.readthedocs.io/en/stable/config-file/v2.html#supported-settings.

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>