### PR TITLE
Fixing a typo (missing closing bracket) in a command

### DIFF
--- a/docs/h2t-pending-pods.md
+++ b/docs/h2t-pending-pods.md
@@ -33,7 +33,7 @@ Viewing the CPU and memory usage statistics on the nodes could help in better al
 Note: <cluster-reader> permission is required to view the usage statistics
 Here are some example command lines that extract just the necessary information.    
 
-` oc get nodes -o yaml | egrep '\sname:|cpu:|memory:' `
+`oc get nodes -o yaml | egrep '\sname:|cpu:|memory:'`
 
 ```
 name: master-0.202-8880.example.com
@@ -43,7 +43,7 @@ name: master-0.202-8880.example.com
       memory: 16715584Ki
 ```
 
-` oc get nodes -o json | jq '.items[] | {name: .metadata.name, cap: .status.capacity' `
+`oc get nodes -o json | jq '.items[] | {name: .metadata.name, cap: .status.capacity'}`
 
 ```
 {


### PR DESCRIPTION
A little typo in Pending Pods page, found by Juraj Petras (thanks!)

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>