### PR TITLE
trying "favicon" attrib under "theme" for ReadtheDocs site...

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ theme:
   name: mkdocs
   nav_style: dark
   navigation_depth: 3
+  favicon: img/favicon.ico
 nav:
   - Home(grown): index.md
   - Contribute: contrib.md


### PR DESCRIPTION
Somehow ReadtheDocs site isn't doing what some mkdocs says it'd do by default. Hence, trying to explicitly specify the file as favicon...

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>