### PR TITLE
Attempt to fix mkdocs build on the site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: openshift-ppc64le
+site_url: http://openshift-ppc64le.readthedocs.io
 theme:
   name: mkdocs
   nav_style: dark
@@ -9,3 +10,6 @@ nav:
   - Contribute: contrib.md
   - External: actually-helped.md
 copyright: © Copyright IBM Corp. 2020, 2021
+plugins:
+  - search
+  - alternate-link


### PR DESCRIPTION
Not exactly sure what's changed, but the internal links are broken on the readthedocs.io site. Here's an attempt, at least works locally..

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>