### PR TITLE
Attempt to fix mkdocs build on the site

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,3 +8,9 @@ version: 2
 # Build documentation with MkDocs
 mkdocs:
   configuration: mkdocs.yml
+
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: git+https://github.com/cmitu/mkdocs-altlink-plugin/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: openshift-ppc64le
+site_url: http://openshift-ppc64le.readthedocs.io
 theme:
   name: mkdocs
   nav_style: dark
@@ -9,3 +10,6 @@ nav:
   - Contribute: contrib.md
   - External: actually-helped.md
 copyright: © Copyright IBM Corp. 2020, 2021
+plugins:
+  - search
+  - alternate-link


### PR DESCRIPTION
Another attempt as the previous one lacked `pip install` bit that the build Docker image ReadTheDocs site would needs for building my site.

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>